### PR TITLE
Fix version number in ChangeLog: 0.9.6->0.9.7

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,4 @@
-0.9.6 (9-Sep-2015):
+0.9.7 (9-Sep-2015):
 * SRs now have `name_label` and `name_description`
 * pull out logging code into a function
 * log state of copying mirrors


### PR DESCRIPTION
There is no 0.9.6 release, these notes are for the 0.9.7 release.

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>