### PR TITLE
CP-22446: Add new cbt_enabled vdi_info param to vdi_create command

### DIFF
--- a/main.ml
+++ b/main.ml
@@ -234,6 +234,7 @@ let vdi_create common_opts sr name descr virtual_size format = match sr with
           snapshot_time = "";
           snapshot_of = "";
           read_only = false;
+          cbt_enabled = false;
           virtual_size = parse_size virtual_size;
           physical_utilisation = 0L;
           sm_config = (match format with None -> [] | Some x -> ["type", x]);


### PR DESCRIPTION
And set it to false by default, because we cannot set the cbt_enabled
parameter at VDI creation time. We have to call VDI.enable_cbt, which
calls some SM functions that do the necessary initialisation.

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>